### PR TITLE
Removing extraneous characters from ruby example

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
 
 @apiSuccess {String} firstname Firstname of the User.
 @apiSuccess {String} lastname  Lastname of the User.
-=end*/</code></pre>
+=end</code></pre>
 				</div>
 			</div>
 		</div>  


### PR DESCRIPTION
The `*/` characters are unneeded in ruby's block commenting. Removing them from the example.
