### PR TITLE
Changed broken plugins link to apidoc-core

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,11 @@ This is a comment.
 
     <article id="extend">
         <h2>Extend</h2>
-        <p>apiDoc can be extended with own parameters (if you miss something). Look at the <a href="https://github.com/apidoc/apidoc/tree/master/lib/plugins">lib/plugins/</a> dir for examples. <code>parser</code> split the parameter data, <code>worker</code> processes additional functions with all found data and <code>filter</code> reduce the data to needed things.</p>
+        <p>apiDoc can be extended with your own parameters (if something is not available that you need). Look at <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/parsers">lib/parsers/</a>, 
+            <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/workers">lib/workers/</a>, and <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/parsers">lib/parsers/</a> 
+            directories in the <a href="https://github.com/apidoc/apidoc-core">apidoc/apidoc-core</a> project for examples. 
+            <code>parser</code> split the parameter data, <code>worker</code> processes additional functions with all found data and <code>filter</code> reduce the data to needed things.
+        </p>
         <p>Example usage: <code>apidoc --parse-filters myFilter=pathToMyFilter/myFilter.js</code></p>
         <p><strong>Or <a href="https://github.com/apidoc/apidoc">fork</a> the whole project and create a pull request to make apiDoc better.</strong></p>
     </article>


### PR DESCRIPTION
It seems that the documentation is referring not to a plugins folder but to three folders. Made those changes.
