### PR TITLE
Update index.html: fix duplicate link

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@ This is a comment.
     <article id="extend">
         <h2>Extend</h2>
         <p>apiDoc can be extended with your own parameters (if something is not available that you need). Look at <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/parsers">lib/parsers/</a>,
-            <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/workers">lib/workers/</a>, and <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/parsers">lib/parsers/</a>
+            <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/workers">lib/workers/</a>, and <a href="https://github.com/apidoc/apidoc-core/tree/master/lib/filters">lib/filters/</a>
             directories in the <a href="https://github.com/apidoc/apidoc-core">apidoc/apidoc-core</a> project for examples.
             <code>parser</code> split the parameter data, <code>worker</code> processes additional functions with all found data and <code>filter</code> reduce the data to needed things.
         </p>


### PR DESCRIPTION
Replace `parser` by `filter`. `parser` is already listed.