### PR TITLE
Fix issues with full example

### DIFF
--- a/source/example_full/_apidoc.js
+++ b/source/example_full/_apidoc.js
@@ -29,10 +29,10 @@
 // Current Permissions.
 // ------------------------------------------------------------------------------------------
 /**
- * @apiDefinePermission admin Admin access rights needed.
+ * @apiDefine admin Admin access rights needed.
  * Optionally you can write here further Informations about the permission.
  *
- * An "apiDefinePermission"-block can have an "apiVersion", so you can attach the block to a specific version.
+ * An "apiDefine"-block can have an "apiVersion", so you can attach the block to a specific version.
  *
  * @apiVersion 0.3.0
  */
@@ -42,7 +42,7 @@
 // History.
 // ------------------------------------------------------------------------------------------
 /**
- * @apiDefinePermission admin This title is visible in version 0.1.0 and 0.2.0
+ * @apiDefine admin This title is visible in version 0.1.0 and 0.2.0
  * @apiVersion 0.1.0
  */
 


### PR DESCRIPTION
If you copy the full example and run `apidoc` you are presented with the error

`{"message":"parser plugin 'apidefinepermission' not found in block: 1","level":"warn"}`

Because this is not how a permissions block is defined.  Per [the documentation]() there is no `apiDefinePermissions` keyword, only `apiDefine`.

This updates the full example to fix that.  See this comment for more details: https://github.com/apidoc/apidocjs.com/issues/23#issuecomment-298321887