### PR TITLE
Add -e to important CLI parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,15 @@ This is a comment.
                     <code>apidoc -t mytemplate/</code>
                 </td>
             </tr>
+            <tr>
+                <td class="code">-e, --exclude-filters</td>
+                <td>
+                    RegEx-Filter to select files / dirs that should not be parsed (many -e can be used). (default: [])<br>
+                    <br>
+                    Example:<br>
+                    <code>apidoc -e node_modules</code>
+                </td>
+            </tr>
             </tbody>
         </table>
     </article>


### PR DESCRIPTION
From Issue 6 from the main [apidoc repo](https://github.com/apidoc/apidoc/issues/6#issue-14364655), I along with [others](https://github.com/apidoc/apidoc/issues/6#issuecomment-152342684) found the -e flag to be important and relevant in the documentation. I added another <tr> to the table for important CLI parameters.