### PR TITLE
fix apiQuery typo and toc entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,6 +196,7 @@
                 <li><a href="#param-api-param-example">@apiParamExample</a></li>
                 <li><a href="#param-api-permission">@apiPermission</a></li>
                 <li><a href="#param-api-private">@apiPrivate</a></li>
+                <li><a href="#param-api-query">@apiQuery</a></li>
                 <li><a href="#param-api-sample-request">@apiSampleRequest</a></li>
                 <li><a href="#param-api-success">@apiSuccess</a></li>
                 <li><a href="#param-api-success-example">@apiSuccessExample</a></li>
@@ -1669,7 +1670,7 @@ This is a comment.
 <!-- ============================================================ -->
 
         <article id="param-api-query">
-            <h2>@apiBody</h2>
+            <h2>@apiQuery</h2>
             <pre><code>@apiQuery [{type}] [field=defaultValue] [description]</code></pre>
             <p>Describe a query parameter passed to your API-Method.</p>
             <p>Usage: <code>@apiQuery {Number} id Users unique ID.</code></p>


### PR DESCRIPTION
Currently `@apiQuery` has no TOC Entry and it's title isn't correct in the documentation